### PR TITLE
Make nothing->value return undef instead of dying with 'Not an ARRAY ref...

### DIFF
--- a/lib/Data/Monad/Maybe.pm
+++ b/lib/Data/Monad/Maybe.pm
@@ -26,7 +26,11 @@ sub flat_map {
 }
 
 sub is_nothing { reftype $_[0] ne 'ARRAY' }
-sub value { wantarray ? @{$_[0]} : $_[0][0] }
+
+sub value {
+    my ($self) = @_;
+    $self->is_nothing ? undef : (wantarray ? @{$_[0]} : $_[0][0])
+}
 
 1;
 

--- a/t/maybe/basic.t
+++ b/t/maybe/basic.t
@@ -16,6 +16,12 @@ sub get_key($) {
 }
 
 {
+    # Check that nothing->value returns undef instead of
+    # dying with 'Not an ARRAY reference'
+    ok ! defined(nothing->value);
+}
+
+{
     my $maybe = $data->flat_map(get_key 'hage')
                      ->flat_map(get_key 'debu')
                      ->flat_map(get_key 'me');


### PR DESCRIPTION
Make nothing->value return undef instead of dying with 'Not an ARRAY reference'

Calling nothing->value (or $any_nothing_value->nothing) was causing 'Not an ARRAY reference' to be raised.

This patch makes it return undef instead.  I've checked it doesn't make the tests fail, and added my own test.
